### PR TITLE
Add display likes functionalities

### DIFF
--- a/src/modules/display-likes.js
+++ b/src/modules/display-likes.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import getAppName from './localstorage';
+import errorMsg from './error-message';
+
+const fetchLikes = async (itemId) => {
+  try {
+    const response = await axios.get(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${getAppName()}/likes/`);
+    const likes = response.data;
+    const itemLikes = likes.find((like) => like.item_id === itemId);
+    return itemLikes ? itemLikes.likes : 0;
+  } catch (error) {
+    errorMsg('Error', 'red');
+    return 0;
+  }
+};
+
+export default fetchLikes;


### PR DESCRIPTION
In this project I;

- Made sure When the page loads, the webapp the [Involvement API](https://www.notion.so/microverse/Involvement-API-869e60b5ad104603aa6db59e08150270) to show the item likes and combines them with the data from the base API
- Ensured there are no linters error
- Used Javascript best practices